### PR TITLE
Fixes #12. Enable range and increment in lhc_sampling

### DIFF
--- a/R/lhc_sampling_netlogo.R
+++ b/R/lhc_sampling_netlogo.R
@@ -44,7 +44,8 @@ lhc_generate_lhc_sample_netlogo <- function(FILEPATH, PARAMETERS, PARAMVALS,
       # Now scale this design, as currently all values are between 0 and 1
       design <- scale_lhc_sample(ParameterInfo$STUDIED_PARAMETERS,
                                  ParameterInfo$PMIN,
-                                 ParameterInfo$PMAX, NUMSAMPLES, design)
+                                 ParameterInfo$PMAX,
+                                 ParameterInfo$PINC, NUMSAMPLES, design)
 
       write_data_to_csv(design, make_path(c(FILEPATH,
                                             "LHC_Parameters_for_Runs.csv")))

--- a/R/netlogo_sampling_utilities.R
+++ b/R/netlogo_sampling_utilities.R
@@ -13,22 +13,32 @@ process_netlogo_parameter_range_info <- function(PARAMETERS, PARAMVALS) {
   STUDIED_PARAMETERS <- NULL
   PMIN <- NULL
   PMAX <- NULL
+  PINC <- NULL
 
   for (PARAM in 1:length(PARAMETERS)) {
 
     PARAMVALSPLIT <- strsplit(PARAMVALS[PARAM], ",")[[1]]
 
-    if (length(PARAMVALSPLIT) > 1) {
+    if (length(PARAMVALSPLIT) == 2) {
       # ADD THE PARAMETER TO THE CSV FILE HEADER
       STUDIED_PARAMETERS <- c(STUDIED_PARAMETERS, PARAMETERS[PARAM])
       # GET THE MIN AND MAX
       PMIN <- c(PMIN,as.numeric(substring(PARAMVALSPLIT[[1]], 2)))
       PMAX <- c(PMAX, as.numeric(substring(PARAMVALSPLIT[[2]], 1,
                                            nchar(PARAMVALSPLIT[[2]]) - 1)))
+      }
+      if (length(PARAMVALSPLIT) == 3) {
+        # ADD THE PARAMETER TO THE CSV FILE HEADER
+        STUDIED_PARAMETERS <- c(STUDIED_PARAMETERS, PARAMETERS[PARAM])
+        # GET THE MIN, MAX and INC
+        PMIN <- c(PMIN, as.numeric(substring(PARAMVALSPLIT[[1]], 2)))
+        PMAX <- c(PMAX, as.numeric(substring(PARAMVALSPLIT[[2]], 1)))
+        PINC <- c(PINC, as.numeric(substring(PARAMVALSPLIT[[3]], 1,
+                                             nchar(PARAMVALSPLIT[[3]]) - 1)))
 
     }
   }
-  return(list("STUDIED_PARAMETERS"=STUDIED_PARAMETERS,"PMIN"=PMIN,"PMAX"=PMAX))
+  return(list("STUDIED_PARAMETERS"=STUDIED_PARAMETERS,"PMIN"=PMIN,"PMAX"=PMAX, "PINC"=PINC))
 }
 
 #' Initialises the Netlogo setup file for this experiment

--- a/tests/testthat/test_lhc_sampling.R
+++ b/tests/testthat/test_lhc_sampling.R
@@ -30,9 +30,10 @@ test_that("scale_lhc_sample", {
   PARAMETERS<-c("A","B")
   PMIN<-c(10,0.1)
   PMAX<-c(100,0.9)
+  PINC<-NULL
   NUMSAMPLES<-500
   design <- sample_parameter_space("normal", 500, PARAMETERS)
-  scaledSample <- scale_lhc_sample(PARAMETERS, PMIN, PMAX, NUMSAMPLES, design)
+  scaledSample <- scale_lhc_sample(PARAMETERS, PMIN, PMAX, PINC, NUMSAMPLES, design)
 
   # Test the characteristics
   expect_equal(nrow(scaledSample),500)
@@ -59,4 +60,3 @@ test_that("lhc_generate_lhc_sample", {
 
   file.remove(paste(getwd(),"/LHC_Parameters_for_Runs.csv",sep=""))
 })
-


### PR DESCRIPTION
This enables using ranges with increments in lhc sampling, both for netlogo and standard version.

New tests may be needed if the pull request is accepted.