### PR TITLE
Fixing inconsistent legend in ploteFASTSiFromTimepointFiles

### DIFF
--- a/R/efast_plotting.R
+++ b/R/efast_plotting.R
@@ -113,7 +113,7 @@ ploteFASTSiFromTimepointFiles <- function(FILEPATH, PARAMETERS, MEASURES,
                      by = as.numeric(max(TIMEPOINTS)) / length(TIMEPOINTS)))
     legend("topleft", inset = .0, title = "Parameter",
            PARAMETERS[1:length(PARAMETERS) - 1],
-           pch = 1:length(PARAMETERS) - 1, cex = 0.75)
+           pch = 2:length(PARAMETERS) - 1, cex = 0.75)
 
     dev.off()
   }


### PR DESCRIPTION
The legend in plot produced by ploteFASTSiFromTimepointFiles does not correspond to the actual plot itself. 
There is a shape in the legend (square in my case) that doesn't exist in the plot, and similarly there is a shape in the plot that is not in the legend.

Upon investigating, I found inconsistencies in the code. When drawing the legend, the pch attribute is set to read from index 1 rather than 2. It should be 2 as lines are drawn starting from index 2 (see line 92). 